### PR TITLE
feat(bcf): Reduce allocations by using CStr8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = {version = "^1", optional = true, features = ["derive"]}
 serde_bytes = {version = "0.11", optional = true}
 thiserror = {version = "^2" }
 url = "2.5"
+cstr8 = "0.1.4"
 
 [features]
 bindgen = ["hts-sys/bindgen"]

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -40,6 +40,7 @@ use std::str;
 
 use crate::htslib;
 
+use cstr8::CStr8;
 use linear_map::LinearMap;
 
 use crate::errors::{Error, Result};
@@ -398,17 +399,14 @@ impl HeaderView {
     }
 
     /// Convert string ID (e.g., for a `FILTER` value) to its numeric identifier.
-    pub fn name_to_id(&self, id: &[u8]) -> Result<Id> {
-        let c_str = ffi::CString::new(id).unwrap();
+    pub fn name_to_id(&self, id: &CStr8) -> Result<Id> {
         unsafe {
             match htslib::bcf_hdr_id2int(
                 self.inner,
                 htslib::BCF_DT_ID as i32,
-                c_str.as_ptr() as *const c_char,
+                id.as_ptr() as *const c_char,
             ) {
-                -1 => Err(Error::BcfUnknownID {
-                    id: str::from_utf8(id).unwrap().to_owned(),
-                }),
+                -1 => Err(Error::BcfUnknownID { id: id.into() }),
                 i => Ok(Id(i as u32)),
             }
         }

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1223,8 +1223,8 @@ mod tests {
         use crate::bcf::header::Id;
 
         assert_eq!(header.id_to_name(Id(4)), b"GT");
-        assert_eq!(header.name_to_id(b"GT").unwrap(), Id(4));
-        assert!(header.name_to_id(b"XX").is_err());
+        assert_eq!(header.name_to_id(cstr8!("GT")).unwrap(), Id(4));
+        assert!(header.name_to_id(cstr8!("XX")).is_err());
     }
 
     #[test]

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -835,6 +835,7 @@ fn bcf_open(target: &[u8], mode: &[u8]) -> Result<*mut htslib::htsFile> {
 
 #[cfg(test)]
 mod tests {
+    use cstr8::cstr8;
     use tempfile::NamedTempFile;
 
     use super::record::Buffer;
@@ -1427,10 +1428,12 @@ mod tests {
 
             record.set_qual(10.0);
 
-            record.push_info_integer(b"N1", &[32]).unwrap();
-            record.push_info_float(b"F1", &[33.0]).unwrap();
-            record.push_info_string(b"S1", &[b"fourtytwo"]).unwrap();
-            record.push_info_flag(b"X1").unwrap();
+            record.push_info_integer(cstr8!("N1"), &[32]).unwrap();
+            record.push_info_float(cstr8!("F1"), &[33.0]).unwrap();
+            record
+                .push_info_string(cstr8!("S1"), &[b"fourtytwo"])
+                .unwrap();
+            record.push_info_flag(cstr8!("X1")).unwrap();
 
             record
                 .push_genotypes(&[
@@ -1442,12 +1445,16 @@ mod tests {
                 .unwrap();
 
             record
-                .push_format_string(b"FS1", &[&b"yes"[..], &b"no"[..]])
+                .push_format_string(cstr8!("FS1"), &[&b"yes"[..], &b"no"[..]])
                 .unwrap();
-            record.push_format_integer(b"FF1", &[43, 11]).unwrap();
-            record.push_format_float(b"FN1", &[42.0, 10.0]).unwrap();
             record
-                .push_format_char(b"CH1", &[b"A"[0], b"B"[0]])
+                .push_format_integer(cstr8!("FF1"), &[43, 11])
+                .unwrap();
+            record
+                .push_format_float(cstr8!("FN1"), &[42.0, 10.0])
+                .unwrap();
+            record
+                .push_format_char(cstr8!("CH1"), &[b"A"[0], b"B"[0]])
                 .unwrap();
 
             // Finally, write out the record.

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -1031,8 +1031,9 @@ impl Record {
     }
 
     /// Add an string-valued INFO tag.
-        let mut buf: Vec<u8> = Vec::new();
     fn push_info_string_impl(&mut self, tag: &CStr8, data: &[&[u8]], ht: u32) -> Result<()> {
+        let data_bytes = data.iter().map(|x| x.len() + 2).sum(); // estimate for buffer pre-alloc
+        let mut buf: Vec<u8> = Vec::with_capacity(data_bytes);
         for (i, &s) in data.iter().enumerate() {
             if i > 0 {
                 buf.extend(b",");


### PR DESCRIPTION
As of today, every time a field is written, a `CString` is allocated as the methods only take `&[u8]` slices, which have no guaranteed `\0` termination.

## Solution

This PR puts the work on the caller -- who probably either has a static list of tags or can pre-allocate and keep references to them around. It changes many of the method signatures to take a [`&CStr8`](https://docs.rs/cstr8/0.1.4/cstr8/struct.CStr8.html), which is a type that ensures the data is both UTF-8 and null-terminated.

I don't have isolated measurements, but alongside some other allocation fixes, this improves the runtime performance of the tool I'm working with by 1.41x when writing large-ish (~500MB) BCF files.

## Alternatives considered

1. Take a `CStr`

	This is a type from the std lib, so there is no external dependency being introduced. Since the tags are also used in error messages, this would introduce UTF-8 checks, albeit in the cold path.

2. Introduce a custom type.

	The cstr8 crate seems to do what we need here but is not very popular and also at version 0.1.x. Making a new custom type would put us in charge of it, with the ability to optimize further.

3. Do nothing. This costs a bunch of performance.

## Downsides of this approach and future actions

- This introduces a new dependency. We might want to make this opaque and re-export most of it.
- Documentation needs to be updated to teach about this.
- We might still want to add a conversion trait and Cow-like type for convenience.
- This PR does not update all places where this could be done, only those that showed up in my profiling.

Please let me know what you think of this. I'm using this branch in the project I'm working on and found no issues, but I also don't use all of rust-htslib. I'll keep this branch up to date.