### PR TITLE
feat: Add support for updating existing aux tags inplace.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -91,6 +91,8 @@ pub enum Error {
     BamAuxUnknownType,
     #[error("failed to add aux field, tag is already present")]
     BamAuxTagAlreadyPresent,
+    #[error("updating the aux field for this datatype is not supported")]
+    BamAuxTagUpdatingNotSupported,
 
     // Errors for base modification fields
     #[error("no base modification tag found for record")]


### PR DESCRIPTION
Add support for updating existing aux tags inplace, by using HTSlib:
 - bam_aux_update_str
 - bam_aux_update_int
 - bam_aux_update_float
 - bam_aux_update_array functions.

Updating aux tags this way will keep the tag at the original location and data of aux tags after get automatically moved if more space was needed when updating a tag inplace.