### PR TITLE
feat: Record::push_aux unchecked escape hatch

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -857,7 +857,14 @@ impl Record {
         if self.aux(tag).is_ok() {
             return Err(Error::BamAuxTagAlreadyPresent);
         }
+        self.push_aux_unchecked(tag, value)
+    }
 
+    /// Add auxiliary data, without checking if the tag is present.
+    ///
+    /// The caller should ensure that the same tag is not pushed more than once.
+    /// This is provided as a performance optimization.
+    pub fn push_aux_unchecked(&mut self, tag: &[u8], value: Aux<'_>) -> Result<()> {
         let ctag = tag.as_ptr() as *mut c_char;
         let ret = unsafe {
             match value {


### PR DESCRIPTION
For newly-created BAM records that may have a lot of aux tags added to them, the overhead of having to check for the existence of each tag before adding it can really add up! Split up the `Record::push_aux` method into two - one with the current behavior, and a new variant, `Record::push_aux_unchecked` that omits the pre-check for the existence of the aux tag.