### PR TITLE
perf(bam): Remove unnecessary heap allocation in `Record::aux`

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1695,6 +1695,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             // fix qual offset
             let qual: Vec<u8> = quals[i].iter().map(|&q| q - 33).collect();
             assert_eq!(rec.qual(), &qual[..]);
+            assert_eq!(rec.aux(b"X"), Err(Error::BamAuxStringError));
             assert_eq!(rec.aux(b"NotAvailableAux"), Err(Error::BamAuxTagNotFound));
         }
 
@@ -2009,7 +2010,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 rec.remove_aux(b"YT").unwrap();
             }
 
-            assert!(rec.remove_aux(b"ab").is_err());
+            assert_eq!(rec.remove_aux(b"X"), Err(Error::BamAuxStringError));
+            assert_eq!(rec.remove_aux(b"ab"), Err(Error::BamAuxTagNotFound));
 
             assert_eq!(rec.aux(b"XS"), Err(Error::BamAuxTagNotFound));
             assert_eq!(rec.aux(b"YT"), Err(Error::BamAuxTagNotFound));

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -644,11 +644,13 @@ impl Record {
     /// Only the first two bytes of a given tag are used for the look-up of a field.
     /// See [`Aux`] for more details.
     pub fn aux(&self, tag: &[u8]) -> Result<Aux<'_>> {
-        let c_str = ffi::CString::new(tag).map_err(|_| Error::BamAuxStringError)?;
+        if tag.len() < 2 {
+            return Err(Error::BamAuxStringError);
+        }
         let aux = unsafe {
             htslib::bam_aux_get(
                 &self.inner as *const htslib::bam1_t,
-                c_str.as_ptr() as *mut c_char,
+                tag.as_ptr() as *const c_char,
             )
         };
         unsafe { Self::read_aux_field(aux).map(|(aux_field, _length)| aux_field) }
@@ -1224,11 +1226,13 @@ impl Record {
 
     // Delete auxiliary tag.
     pub fn remove_aux(&mut self, tag: &[u8]) -> Result<()> {
-        let c_str = ffi::CString::new(tag).map_err(|_| Error::BamAuxStringError)?;
+        if tag.len() < 2 {
+            return Err(Error::BamAuxStringError);
+        }
         let aux = unsafe {
             htslib::bam_aux_get(
                 &self.inner as *const htslib::bam1_t,
-                c_str.as_ptr() as *mut c_char,
+                tag.as_ptr() as *const c_char,
             )
         };
         unsafe {


### PR DESCRIPTION
Remove the unnecessary heap allocation in `Record::aux` and `Record::remove_aux` by removing the call to `CString::new` and using the `tag` byte slice directly. The BAM tag passed to `htslib::bam_aux_get` does not need to be null terminated. Return `Error::BamAuxStringError` if the length of the tag is less than two characters.

See [bam_aux_get](https://github.com/samtools/htslib/blob/58ca3d47ba7d5aaef80bbcf42f7485ee980107e8/sam.c#L4834)
