### PR TITLE
fix: empty_header was making a deep copy of header

### DIFF
--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -513,8 +513,8 @@ impl HeaderView {
     /// Create an empty record using this header view.
     ///
     /// The record can be reused multiple times.
-    pub fn empty_record(&self) -> crate::bcf::Record {
-        crate::bcf::Record::new(Rc::new(self.clone()))
+    pub fn empty_record(self: &Rc<Self>) -> crate::bcf::Record {
+        crate::bcf::Record::new(Rc::clone(self))
     }
 }
 


### PR DESCRIPTION
closes #493

I introduced this between 0.48.0 and 0.49.0 :man_facepalming: 

this does an Rc:clone() instead of a HeaderView::clone() which was doing a deep copy of the header. this has pretty big performance consequences.

ping @johanneskoester 