### PR TITLE
fix(bcf): interpretation of indexed reader initialisation return code

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1029,8 +1029,8 @@ impl Read for IndexedReader {
 impl Drop for IndexedReader {
     fn drop(&mut self) {
         unsafe {
-            if self.itr.is_some() {
-                htslib::hts_itr_destroy(self.itr.unwrap());
+            if let Some(itr) = self.itr {
+                htslib::hts_itr_destroy(itr);
             }
             htslib::hts_close(self.htsfile);
         }

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -295,10 +295,12 @@ impl IndexedReader {
         // Create reader and require existence of index file.
         let ser_reader = unsafe { htslib::bcf_sr_init() };
         unsafe {
+            // 0: BCF_SR_REQUIRE_IDX
             htslib::bcf_sr_set_opt(ser_reader, 0);
-        } // 0: BCF_SR_REQUIRE_IDX
-          // Attach a file with the path from the arguments.
-        if unsafe { htslib::bcf_sr_add_reader(ser_reader, path.as_ptr()) } >= 0 {
+        }
+        // Attach a file with the path from the arguments. 1 = success, 0 = fail
+        // https://github.com/samtools/htslib/blob/develop/htslib/synced_bcf_reader.h#L232
+        if unsafe { htslib::bcf_sr_add_reader(ser_reader, path.as_ptr()) } != 0 {
             let header = Arc::new(unsafe {
                 HeaderView::from_ptr(htslib::bcf_hdr_dup(
                     (*(*ser_reader).readers.offset(0)).header,

--- a/src/tbx/mod.rs
+++ b/src/tbx/mod.rs
@@ -316,8 +316,8 @@ impl Read for Reader {
 impl Drop for Reader {
     fn drop(&mut self) {
         unsafe {
-            if self.itr.is_some() {
-                htslib::hts_itr_destroy(self.itr.unwrap());
+            if let Some(itr) = self.itr {
+                htslib::hts_itr_destroy(itr);
             }
             htslib::tbx_destroy(self.tbx);
             htslib::hts_close(self.hts_file);


### PR DESCRIPTION
There is a small error in the initialisation code of the bcf `IndexedReader`: The return status of the underlying `htslib` method `bcf_sr_add_reader` is misinterpreted. For example, if the index file is missing, the underlying method fails, but the method here still returns success. This, in turn, caused (in my case) a segmentation fault downstream when trying to access fields or read from the reader.

See here the return value, clearly `!= 0` is more appropriate check than `>= 0`.
https://github.com/samtools/htslib/blob/d94071f3dd9613ab66f177e1237660855a56f0ed/htslib/synced_bcf_reader.h#L260 (edit: update link because upstream changes)