### PR TITLE
fix: add null check to tidname on HeaderView

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1439,7 +1439,13 @@ impl HeaderView {
     }
 
     pub fn tid2name(&self, tid: u32) -> &[u8] {
-        unsafe { ffi::CStr::from_ptr(htslib::sam_hdr_tid2name(self.inner, tid as i32)).to_bytes() }
+        // unsafe { ffi::CStr::from_ptr(htslib::sam_hdr_tid2name(self.inner, tid as i32)).to_bytes() }
+        let ptr = unsafe { htslib::sam_hdr_tid2name(self.inner, tid as i32) };
+        if ptr.is_null() {
+            b"" 
+        } else {
+            unsafe { ffi::CStr::from_ptr(ptr).to_bytes() }
+        }
     }
 
     pub fn target_count(&self) -> u32 {
@@ -3181,6 +3187,13 @@ CCCCCCCCCCCCCCCCCCC"[..],
         ];
         let actual = reader.index_stats().unwrap();
         assert_eq!(expected, actual);
+    }
+    
+    #[test]
+    fn test_nonexistent_tidname() {
+        let header = Header::new();
+        let header_view = HeaderView::from_header(&header);
+        assert_eq!(b"", header_view.tid2name(0));
     }
 
     // #[test]

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1441,7 +1441,7 @@ impl HeaderView {
     pub fn tid2name(&self, tid: u32) -> &[u8] {
         let ptr = unsafe { htslib::sam_hdr_tid2name(self.inner, tid as i32) };
         if ptr.is_null() {
-            b"" 
+            b""
         } else {
             unsafe { ffi::CStr::from_ptr(ptr).to_bytes() }
         }
@@ -3187,7 +3187,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let actual = reader.index_stats().unwrap();
         assert_eq!(expected, actual);
     }
-    
+
     #[test]
     fn test_nonexistent_tidname() {
         let header = Header::new();

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1439,7 +1439,6 @@ impl HeaderView {
     }
 
     pub fn tid2name(&self, tid: u32) -> &[u8] {
-        // unsafe { ffi::CStr::from_ptr(htslib::sam_hdr_tid2name(self.inner, tid as i32)).to_bytes() }
         let ptr = unsafe { htslib::sam_hdr_tid2name(self.inner, tid as i32) };
         if ptr.is_null() {
             b"" 


### PR DESCRIPTION
This fixes: https://github.com/rust-bio/rust-htslib/issues/505 by adding a null check to `tid2name`. also, added a test for the segfaulting example. Returning empty `CStr` on missing tid (when the C ffi return NULL) should also be documented.  